### PR TITLE
Fix typos and several other

### DIFF
--- a/script/lteipchecker-telnet.sh
+++ b/script/lteipchecker-telnet.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 while sleep 5; do
-{ echo "nvram_get cache wan_ipaddr"; echo "nvram_get cache wan_primary_dns"; sleep 2; } | telnet 169.254.0.1|grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'|grep -v "169.254.0.1"  > /tmp/ipmodem.txt
+{ echo "nvram_get cache wan_ipaddr"; echo "nvram_get cache wan_primary_dns"; sleep 2; } | telnet 169.254.0.1 | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -v "169.254.0.1"  > /tmp/ipmodem.txt
 
-ethdataip=`ifconfig modem.103 | grep 'inet addr' | cut -d: -f2 | awk '{print $1}'`
-lteip=`head -1 /tmp/ipmodem.txt`
-ltedns=`tail -1 /tmp/ipmodem.txt`
+ethdataip=$(ifconfig modem.103 | grep 'inet addr' | cut -d: -f2 | awk '{print $1}')
+lteip=$(head -1 /tmp/ipmodem.txt)
+ltedns=$(tail -1 /tmp/ipmodem.txt)
+
 if [ -z "$lteip" ]
 then
       echo "IP modem tidak dapat di cek"

--- a/script/lteipchecker-telnet.sh
+++ b/script/lteipchecker-telnet.sh
@@ -7,12 +7,12 @@ lteip=`head -1 /tmp/ipmodem.txt`
 ltedns=`tail -1 /tmp/ipmodem.txt`
 if [ -z "$lteip" ]
 then
-      echo "Ip modem tidak dapat di cek"
+      echo "IP modem tidak dapat di cek"
 else
      if [[ "$ethdataip" != "$lteip" ]];then
-        echo " eth_data $ethdataip \n LTE IP $lteip dns $ltedns"
+        echo "eth_data $ethdataip \n LTE IP $lteip dns $ltedns"
          #ifconfig modem.103 $lteip netmask 255.255.255.255 up
-        logger -p notice -t lte "IP berubah dar $ethdata menjadi $lteip dns $ltedns"
+        logger -p notice -t lte "IP berubah dari $ethdataip menjadi $lteip dns $ltedns"
          uci set network.eth_data.ipaddr="$lteip"
          uci set network.eth_data.dns="$ltedns"
          uci commit network


### PR DESCRIPTION
- Fix typos (upper/lowercase, whitespace, `$ethdata` is not defined but `$ethdataip` is...)
- make the codes more uniform (to space or not to space after `|` ?)
- replace backticks with `$(...)` (see: [SC2006](https://github.com/koalaman/shellcheck/wiki/SC2006))

I confirm that the script still work on my router...